### PR TITLE
Add shortstop WAR+ calculation

### DIFF
--- a/pybaseball/__init__.py
+++ b/pybaseball/__init__.py
@@ -101,4 +101,5 @@ from .plotting import plot_strike_zone
 from .datasources.fangraphs import (fg_batting_data, fg_pitching_data, fg_team_batting_data, fg_team_fielding_data,
                                     fg_team_pitching_data)
 from .split_stats import get_splits
+from .analysis.warplus import shortstop_warplus
 from .version import __version__

--- a/pybaseball/analysis/warplus.py
+++ b/pybaseball/analysis/warplus.py
@@ -1,0 +1,46 @@
+from datetime import timedelta
+from typing import Optional
+import pandas as pd
+
+from ..league_batting_stats import batting_stats_range, bwar_bat
+from ..utils import sanitize_date_range
+from ..enums.fangraphs import FangraphsPositions
+
+
+def shortstop_warplus(start_dt: Optional[str] = None, end_dt: Optional[str] = None) -> pd.DataFrame:
+    """Calculate WAR+ for shortstops over a given date range.
+
+    If no dates are supplied, the range defaults to the last seven days.
+    WAR+ is defined as a player's WAR over the period divided by the average WAR
+    for all shortstops in that period, multiplied by 100.
+    """
+    start_date, end_date = sanitize_date_range(start_dt, end_dt)
+    if start_dt is None and end_dt is None:
+        start_date = end_date - timedelta(days=6)
+
+    start_str = start_date.strftime("%Y-%m-%d")
+    end_str = end_date.strftime("%Y-%m-%d")
+
+    batting = batting_stats_range(start_str, end_str)
+    pos_cols = [c for c in batting.columns if "Pos" in c]
+    if pos_cols:
+        pos_col = pos_cols[0]
+        batting = batting[batting[pos_col].str.contains("SS", case=False, na=False)]
+
+    war_data = bwar_bat(return_all=True)
+    if "date_ID" in war_data.columns:
+        war_data["date_ID"] = pd.to_datetime(war_data["date_ID"])
+        mask = (war_data["date_ID"] >= start_date) & (war_data["date_ID"] <= end_date)
+    else:
+        mask = pd.Series(False, index=war_data.index)
+
+    position_mask = war_data.get("pos", "") == FangraphsPositions.SHORT_STOP.value
+    war_period = war_data.loc[mask & position_mask]
+    war_by_player = war_period.groupby("mlb_ID")["WAR"].sum()
+
+    avg_war = war_by_player.mean() if not war_by_player.empty else 0
+    war_plus = (war_by_player / avg_war * 100).rename("WAR_plus") if avg_war else war_by_player * 0
+
+    result = pd.concat([war_by_player.rename("WAR"), war_plus], axis=1).reset_index()
+    return result
+

--- a/tests/pybaseball/analysis/test_warplus.py
+++ b/tests/pybaseball/analysis/test_warplus.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from pybaseball.analysis.warplus import shortstop_warplus
+
+
+def test_shortstop_warplus(monkeypatch):
+    batting_df = pd.DataFrame({
+        'mlbID': [1, 2],
+        'Pos Summary': ['SS', '2B'],
+    })
+    war_df = pd.DataFrame({
+        'mlb_ID': [1, 1, 2],
+        'date_ID': ['2021-07-01', '2021-07-02', '2021-07-02'],
+        'pos': ['ss', 'ss', '2b'],
+        'WAR': [0.1, 0.2, 0.05],
+    })
+
+    def batting_mock(start_dt, end_dt):
+        return batting_df
+
+    def war_mock(return_all=False):
+        assert return_all
+        return war_df
+
+    monkeypatch.setattr('pybaseball.analysis.warplus.batting_stats_range', batting_mock)
+    monkeypatch.setattr('pybaseball.analysis.warplus.bwar_bat', war_mock)
+
+    result = shortstop_warplus('2021-07-01', '2021-07-02')
+
+    assert not result.empty
+    assert 'WAR_plus' in result.columns
+    assert result.loc[0, 'WAR_plus'] == 100.0
+


### PR DESCRIPTION
## Summary
- compute WAR+ for shortstops over a date range in new `shortstop_warplus`
- expose `shortstop_warplus` at the package level
- test WAR+ calculation logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68418fa76c64833191605e6dd0b8ff03