### PR TITLE
Fix top prospects fetch and add unit test

### DIFF
--- a/pybaseball/top_prospects.py
+++ b/pybaseball/top_prospects.py
@@ -23,16 +23,17 @@ def top_prospects(teamName=None, playerType=None):
         mlbTeamId = teamid_lookup.mlb_team_id(teamName)
         url = f"https://www.mlb.com/prospects/stats?teamId={mlbTeamId}"
 
-    res = requests.get(
+    response = requests.get(
         url,
         timeout=None,
         headers={
-            "UserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) C"
-            "hrome/104.0.5112.79 Safari/537.36"
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/104.0.5112.79 Safari/537.36"
         },
-    ).content
-    prospectList = pd.read_html(res)
+    )
+    response.raise_for_status()
+    prospectList = pd.read_html(response.content)
     
     if playerType == "batters":
         topBattingProspects = postprocess(prospectList[0])

--- a/tests/pybaseball/data/top_prospects.html
+++ b/tests/pybaseball/data/top_prospects.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+<table>
+<thead><tr><th>Unnamed: 0</th><th>Rk</th><th>Tm</th><th>Name</th></tr></thead>
+<tbody>
+<tr><td>0</td><td>1</td><td>HOU</td><td>Batter A</td></tr>
+</tbody>
+</table>
+<table>
+<thead><tr><th>Unnamed: 0</th><th>Rk</th><th>Tm</th><th>Name</th></tr></thead>
+<tbody>
+<tr><td>0</td><td>1</td><td>HOU</td><td>Pitcher A</td></tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/tests/pybaseball/test_top_prospects.py
+++ b/tests/pybaseball/test_top_prospects.py
@@ -1,0 +1,33 @@
+from typing import Callable
+
+import pandas as pd
+import requests
+from pytest import MonkeyPatch
+
+from pybaseball.top_prospects import top_prospects
+
+
+def test_top_prospects_returns_dataframe(monkeypatch: MonkeyPatch, get_data_file_contents: Callable[[str], str]) -> None:
+    html = get_data_file_contents('top_prospects.html')
+    expected_url = 'https://www.mlb.com/prospects/stats?teamId=117'
+
+    def fake_get(url: str, params: None = None, timeout: None = None, headers: None = None):
+        assert url == expected_url
+
+        class DummyResponse:
+            def __init__(self, content: str):
+                self.content = content.encode("utf-8")
+
+            def raise_for_status(self) -> None:  # pragma: no cover - no failure path
+                pass
+
+        return DummyResponse(html)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = top_prospects("astros")
+
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty
+
+


### PR DESCRIPTION
## Summary
- clean up `top_prospects` request handling
- add minimal unit test for `top_prospects`
- provide mock HTML for top prospects test

## Testing
- `pytest tests/pybaseball/test_top_prospects.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684234034ca083318491d4467c667a30