### PR TITLE
Expand spin_components test coverage

### DIFF
--- a/tests/pybaseball/analysis/trajectories/batted_balls/test_batted_balls_utils.py
+++ b/tests/pybaseball/analysis/trajectories/batted_balls/test_batted_balls_utils.py
@@ -7,9 +7,59 @@ from pybaseball.analysis.trajectories.utils import unit_vector, spin_components
 
 @pytest.mark.parametrize(
     "spin, spin_angle, launch_angle, launch_direction_angle, expected",
-    [(0, 1, 1, 1, (0, 0, 0))],
+    [
+        # no spin should yield zero components
+        (0, 1, 1, 1, (0, 0, 0)),
+        # typical backspin dominated case
+        (
+            2000,
+            30,
+            20,
+            0,
+            (
+                181.37993642342178,
+                -35.816265655054956,
+                98.40438113645162,
+            ),
+        ),
+        # non-zero launch direction with mild spin angle
+        (
+            1500,
+            10,
+            45,
+            60,
+            (
+                60.64318699343772,
+                -143.61200729546908,
+                19.287463144967436,
+            ),
+        ),
+        # negative launch and spin angles
+        (
+            1500,
+            -45,
+            -10,
+            -30,
+            (
+                105.83496883462354,
+                38.832603668881674,
+                -109.38463908060042,
+            ),
+        ),
+        # sidespin only
+        (
+            3000,
+            90,
+            0,
+            45,
+            (
+                0.0,
+                -0.0,
+                314.1592653589793,
+            ),
+        ),
+    ],
 )
-# TODO: add additional tests
 def test_spin_components(
     spin, spin_angle, launch_angle, launch_direction_angle, expected
 ):


### PR DESCRIPTION
## Summary
- add multiple cases for `spin_components` including negative angles and high sidespin

## Testing
- `pytest -q tests/pybaseball/analysis/trajectories/batted_balls/test_batted_balls_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684269b4b9a88331af70ca371665c73c