### PR TITLE
Clean up typeshed work-around

### DIFF
--- a/tests/pybaseball/profiling.py
+++ b/tests/pybaseball/profiling.py
@@ -101,8 +101,7 @@ if __name__ == "__main__":
     # Print stats
     profiler.disable()
     stats_stream = io.StringIO()
-    profiler_stats = pstats.Stats(profiler, stream=stats_stream).sort_stats(pstats.SortKey.PCALLS) # type: ignore
-    # TODO: After https://github.com/python/typeshed/pull/4523 is integrated into a mypy release, remove ^ type annotation
+    profiler_stats = pstats.Stats(profiler, stream=stats_stream).sort_stats(pstats.SortKey.PCALLS)
     profiler_stats.print_stats()
     try:
         print(stats_stream.getvalue())


### PR DESCRIPTION
## Summary
- confirm typeshed PR 4523 is merged
- drop now unnecessary `# type: ignore`

## Testing
- `pip install -e .[test]`
- `make test` *(fails: interrupted)*
- `make mypy ONLY_MODIFIED=1` *(fails: existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684269ba2c388331b41a1b5ce3041c0e