### PR TITLE
Fix team results table exception

### DIFF
--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -26,8 +26,10 @@ def get_soup(season: Optional[int], team: str) -> BeautifulSoup:
 def get_table(soup: BeautifulSoup, team: str) -> pd.DataFrame:
     try:
         table = soup.find_all('table')[0]
-    except:
-        raise ValueError("Data cannot be retrieved for this team/year combo. Please verify that your team abbreviation is accurate and that the team existed during the season you are searching for.")
+    except IndexError:
+        raise ValueError(
+            "Data cannot be retrieved for this team/year combo. Please verify that your team abbreviation is accurate and that the team existed during the season you are searching for."
+        )
     data = []
     headings = [th.get_text() for th in table.find("tr").find_all("th")]
     headings = headings[1:] # the "gm#" heading doesn't have a <td> element

--- a/tests/pybaseball/test_team_results_unit.py
+++ b/tests/pybaseball/test_team_results_unit.py
@@ -1,0 +1,19 @@
+import pytest
+from bs4 import BeautifulSoup
+
+import pybaseball.team_results as tr
+
+
+def test_schedule_and_record_invalid_team(monkeypatch):
+    def fake_get_soup(season, team):
+        return BeautifulSoup("<html></html>", "lxml")
+
+    monkeypatch.setattr(tr, "get_soup", fake_get_soup)
+
+    with pytest.raises(ValueError):
+        tr.schedule_and_record(2019, "TBR")
+
+
+def test_schedule_and_record_invalid_season(monkeypatch):
+    with pytest.raises(ValueError):
+        tr.schedule_and_record(1995, "TBR")


### PR DESCRIPTION
## Summary
- raise IndexError when team results table not found
- add tests for invalid team or season

## Testing
- `pytest tests/pybaseball/test_team_results_unit.py -q`
- `pytest -q` *(fails: ProxyError during integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_684269819d608331a71ac9b9282a8047