### PR TITLE
Introduce logging for URLs and warnings

### DIFF
--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional
+import logging
 
 from bs4 import BeautifulSoup
 import numpy as np
@@ -12,6 +13,9 @@ from .datasources.bref import BRefSession
 
 session = BRefSession()
 
+# module level logger
+logger = logging.getLogger("pybaseball")
+
 # TODO: retrieve data for all teams? a full season's worth of results
 
 def get_soup(season: Optional[int], team: str) -> BeautifulSoup:
@@ -19,7 +23,7 @@ def get_soup(season: Optional[int], team: str) -> BeautifulSoup:
     if season is None:
         season = most_recent_season()
     url = "http://www.baseball-reference.com/teams/{}/{}-schedule-scores.shtml".format(team, season)
-    print(url)
+    logger.info(url)
     s = session.get(url).content
     return BeautifulSoup(s, "lxml")
 

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -4,9 +4,13 @@ import functools
 import io
 from typing import Dict, Iterator, Optional, Tuple, Union
 import zipfile
+import logging
 
 import pandas as pd
 import requests
+
+# module level logger
+logger = logging.getLogger("pybaseball")
 
 from . import cache
 
@@ -177,11 +181,11 @@ def date_range(start: date, stop: date, step: int = 1, verbose: bool = True) -> 
 		if (low.month, low.day) < (3, 15):
 			low = low.replace(month=3, day=15)
 			if verbose:
-				print('Skipping offseason dates')
+				logger.info('Skipping offseason dates')
 		elif (low.month, low.day) > (11, 15):
 			low = low.replace(month=3, day=15, year=low.year + 1)
 			if verbose:
-				print('Skipping offseason dates')
+				logger.info('Skipping offseason dates')
 
 		if low > stop:
 			return
@@ -205,11 +209,11 @@ def statcast_date_range(start: date, stop: date, step: int, verbose: bool = True
 		if low < season_start:
 			low = season_start
 			if verbose:
-				print('Skipping offseason dates')
+				logger.info('Skipping offseason dates')
 		elif low > season_end:
 			low, _ = STATCAST_VALID_DATES.get(low.year + 1, (date(month=3, day=15, year=low.year + 1), None))
 			if verbose:
-				print('Skipping offseason dates')
+				logger.info('Skipping offseason dates')
 
 		if low > stop:
 			return
@@ -235,10 +239,10 @@ def sanitize_date_range(start_dt: Optional[str], end_dt: Optional[str]) -> Tuple
 		start_dt = str(today - timedelta(1))
 		end_dt = str(today)
 
-		print('start_dt', start_dt)
-		print('end_dt', end_dt)
+		logger.info('start_dt %s', start_dt)
+		logger.info('end_dt %s', end_dt)
 
-		print("Warning: no date range supplied, assuming yesterday's date.")
+		logger.warning("Warning: no date range supplied, assuming yesterday's date.")
 
 	# If only one date is supplied, assume they only want that day's stats
 	# query in this case is from date 1 to date 1
@@ -281,7 +285,7 @@ def split_request(start_dt: str, end_dt: str, player_id: int, url: str) -> pd.Da
 	end_dt_datetime = datetime.strptime(end_dt, '%Y-%m-%d')
 	results = []  # list to hold data as it is returned
 	player_id_str = str(player_id)
-	print('Gathering Player Data')
+	logger.info('Gathering Player Data')
 	# break query into multiple requests
 	while current_dt <= end_dt_datetime:
 		remaining = end_dt_datetime - current_dt

--- a/tests/pybaseball/test_utils.py
+++ b/tests/pybaseball/test_utils.py
@@ -2,13 +2,17 @@ from datetime import date, datetime, timedelta
 
 import pytest
 
+import logging
+from _pytest.logging import LogCaptureFixture
 from pybaseball.utils import DATE_FORMAT, sanitize_date_range
 
 
-def test_sanitize_date_range_nones() -> None:
+def test_sanitize_date_range_nones(caplog: LogCaptureFixture) -> None:
     yesterday = date.today() - timedelta(days=1)
 
-    start_dt, end_dt = sanitize_date_range(None, None)
+    with caplog.at_level(logging.WARNING):
+        start_dt, end_dt = sanitize_date_range(None, None)
+        assert "Warning: no date range supplied, assuming yesterday's date." in caplog.text
 
     assert start_dt == yesterday
     assert end_dt == date.today()


### PR DESCRIPTION
## Summary
- add module-level loggers to `team_results` and `utils`
- replace prints with `logger.info` or `logger.warning`
- update util tests to check logged warning

## Testing
- `make mypy`
- `make test` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68426959fe048331b3e4bfacc854a03a