### PR TITLE
Implement schedule_and_record all-team option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Batting stats are obtained similarly. The function call for getting a season-lev
 
 (For season level queries, if you prefer Baseball Reference to FanGraphs, there is a third option, `pitching_stats_bref(season)`. This works the same as `pitching_stats`, but retrieves its data from Baseball Reference instead. This is *not recommended*, however, because the Baseball Reference query currently can only retrieve one season's worth of data per request.)
 
-### Game-by-Game Results and Schedule 
-The `schedule_and_record` function returns a team's game-by-game results for a given season. The function's only two arguments are `season` and `team`, where team is the team's abbreviation (i.e. NYY for New York Yankees).
+### Game-by-Game Results and Schedule
+The `schedule_and_record` function returns a team's game-by-game results for a given season. Pass `team` as the team's abbreviation (i.e. NYY for New York Yankees). If `team` is omitted or `None`, results for all MLB teams in that season are returned.
 
 ```python
 # Example: Say we want to know the 1927 Yankees record on May 16 
@@ -136,6 +136,10 @@ data = schedule_and_record(1927, 'NYY')
 data.loc[data.Date.str.contains("May 16"), :]
               Date   Tm Home_Away  Opp W/L    R   RA  Inn   W-L  Rank      GB      Win      Loss   Save  Time D/N  Attendance   cLI  Streak Orig. Scheduled
 28  Monday, May 16  NYY         @  DET   W  6.0  2.0  9.0  19-8   1.0  up 3.0  Ruether  Holloway  Moore  2:28   D      4000.0  5.15       5            None
+```
+```python
+# All teams' schedules for 2017
+all_teams = schedule_and_record(2017)
 ```
 
 

--- a/docs/schedule_and_record.md
+++ b/docs/schedule_and_record.md
@@ -1,13 +1,14 @@
 # Schedule and Record
 
-`schedule_and_record(season, team)`
+`schedule_and_record(season, team=None)`
 
 The schedule_and_record function returns a dataframe of a team's game-level results for a given season, including win/loss/tie result, score, attendance, and winning/losing/saving pitcher. If the season is incomplete, it will provide scheduling information for future games. 
 
 ## Arguments
 `season:` Integer. The season for which you want a team's record data. 
 
-`team:` String. The abbreviation of the team for which you are requesting data (e.g. "PHI", "BOS", "LAD"). 
+`team:` String, optional. The abbreviation of the team for which you are requesting data (e.g. "PHI", "BOS", "LAD").
+If omitted or ``None``, the schedules and results for all MLB teams are returned for the specified season.
 
 Note that if a team did not exist during the year you are requesting data for, the query will be unsuccessful. Historical name and city changes for teams in older seasons can cause some problems as well. The Los Angeles Dodgers ("LAD"), for example, are abbreviated "BRO" in older seasons, due to their origins as the Brooklyn Dodgers. This may at times require some detective work in certain cases.   
 
@@ -21,4 +22,7 @@ data = schedule_and_record(1927, "NYY")
 
 # Results and upcoming schedule for the Phillies' current season (2017 at the time of writing)
 data = schedule_and_record(2017, "PHI")
+
+# Retrieve the full league schedule for 2017
+all_teams = schedule_and_record(2017)
 ```

--- a/tests/pybaseball/test_team_results_unit.py
+++ b/tests/pybaseball/test_team_results_unit.py
@@ -1,11 +1,12 @@
 import pytest
 from bs4 import BeautifulSoup
+import pandas as pd
 
 import pybaseball.team_results as tr
 
 
-def test_schedule_and_record_invalid_team(monkeypatch):
-    def fake_get_soup(season, team):
+def test_schedule_and_record_invalid_team(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get_soup(season: int, team: str) -> BeautifulSoup:
         return BeautifulSoup("<html></html>", "lxml")
 
     monkeypatch.setattr(tr, "get_soup", fake_get_soup)
@@ -14,6 +15,29 @@ def test_schedule_and_record_invalid_team(monkeypatch):
         tr.schedule_and_record(2019, "TBR")
 
 
-def test_schedule_and_record_invalid_season(monkeypatch):
+def test_schedule_and_record_invalid_season(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(ValueError):
         tr.schedule_and_record(1995, "TBR")
+
+
+def test_schedule_and_record_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_df = pd.DataFrame({"Tm": ["AAA"], "R": [1], "Attendance": ["0"], "Streak": ["+"]})
+
+    def fake_get_soup(season: int, team: str) -> BeautifulSoup:
+        return BeautifulSoup("<html></html>", "lxml")
+
+    def fake_get_table(soup: BeautifulSoup, team: str) -> pd.DataFrame:
+        df = fake_df.copy()
+        df['Tm'] = team
+        return df
+
+    monkeypatch.setattr(tr, "get_soup", fake_get_soup)
+    monkeypatch.setattr(tr, "get_table", fake_get_table)
+    monkeypatch.setattr(tr, "process_win_streak", lambda df: df)
+    monkeypatch.setattr(tr, "make_numeric", lambda df: df)
+    monkeypatch.setattr(tr.teamid_lookup, "team_ids", lambda season: pd.DataFrame({'teamIDBR': ['AAA', 'BBB']}))
+
+    result = tr.schedule_and_record(2020)
+
+    assert list(result['Tm']) == ['AAA', 'BBB']
+


### PR DESCRIPTION
## Summary
- allow `schedule_and_record` to retrieve every MLB team's schedule by using `team=None`
- document the new behaviour
- update examples in docs and README
- test new functionality

## Testing
- `make mypy`
- `make test` *(fails: AttributeError in cache tests)*

------
https://chatgpt.com/codex/tasks/task_e_68426cda779c83319bf973ffac72da5e