### PR TITLE
Add Python 3.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Pybaseball can be installed via pip:
 pip install pybaseball
 ```
 
+Pybaseball supports Python 3.8 through 3.12.
+
 or from the repo (which may at times be more up to date):
 
 ```bash

--- a/pybaseball/cache/cache_config.py
+++ b/pybaseball/cache/cache_config.py
@@ -13,6 +13,15 @@ class CacheConfig(singleton.Singleton):
     CFG_FILENAME = 'cache_config.json'
     PYBASEBALL_CACHE_ENV = 'PYBASEBALL_CACHE'
 
+    @property
+    def cache_directory(self) -> str:
+        return self._cache_directory
+
+    @cache_directory.setter
+    def cache_directory(self, directory: str) -> None:
+        self._cache_directory = directory
+        file_utils.mkdir(self._cache_directory)
+
     def __init__(self, enabled: bool = False, default_expiration: int = None, cache_type: Optional[str] = None):
         self.enabled = enabled
         self.cache_directory = os.environ.get(CacheConfig.PYBASEBALL_CACHE_ENV) or CacheConfig.DEFAULT_CACHE_DIR
@@ -24,7 +33,7 @@ class CacheConfig(singleton.Singleton):
         else:
             self.cache_type = CacheConfig.DEFAULT_CACHE_TYPE
 
-        file_utils.mkdir(self.cache_directory)
+        # cache_directory setter handles creating the directory
 
     def enable(self, enabled: bool = True) -> None:
         self.enabled = enabled

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     # What does your project relate to?

--- a/tests/pybaseball/cache/test_cache.py
+++ b/tests/pybaseball/cache/test_cache.py
@@ -237,7 +237,7 @@ def test_purge(remove: MagicMock) -> None:
         with patch('pybaseball.cache.file_utils.load_json', mock_load_json):
             cache.purge()
 
-    assert glob_mock.called_once()
+    glob_mock.assert_called_once()
     assert mock_load_json.call_count == len(glob_result)
     assert remove.call_count == len(glob_result)
 
@@ -256,6 +256,6 @@ def test_flush(remove: MagicMock) -> None:
         with patch('pybaseball.cache.file_utils.load_json', mock_load_json):
             cache.flush()
 
-    assert glob_mock.called_once()
+    glob_mock.assert_called_once()
     assert mock_load_json.call_count == len(glob_result)
     remove.assert_called_once()

--- a/tests/pybaseball/cache/test_cache_config.py
+++ b/tests/pybaseball/cache/test_cache_config.py
@@ -31,7 +31,7 @@ def test_enable() -> None:
 def test_cache_directory_default(mkdir: MagicMock) -> None:
     config = cache.CacheConfig()
     assert config.cache_directory == cache.CacheConfig.DEFAULT_CACHE_DIR
-    assert mkdir.called_once_with(cache.CacheConfig.DEFAULT_CACHE_DIR)
+    mkdir.assert_called_once_with(parents=True, exist_ok=True)
 
 
 def test_cache_directory_set(mkdir: MagicMock) -> None:
@@ -39,7 +39,7 @@ def test_cache_directory_set(mkdir: MagicMock) -> None:
     cache.config.cache_directory = my_dir
 
     assert cache.config.cache_directory == my_dir
-    assert mkdir.called_once_with(my_dir)
+    mkdir.assert_called_once_with(parents=True, exist_ok=True)
 
 
 def test_expiration_default() -> None:

--- a/tests/pybaseball/cache/test_dataframe_utils.py
+++ b/tests/pybaseball/cache/test_dataframe_utils.py
@@ -25,7 +25,10 @@ def test_load(monkeypatch: MonkeyPatch, cache_type: str, method: str) -> None:
 
     cache.dataframe_utils.load_df(test_filename)
 
-    assert read_mock.called_once_with(test_filename)
+    if method == 'read_csv':
+        read_mock.assert_called_once_with(test_filename, index_col=0)
+    else:
+        read_mock.assert_called_once_with(test_filename)
 
 def test_load_invalid_cache_type() -> None:
     test_filename = 'test.exe'
@@ -47,7 +50,7 @@ def test_save(monkeypatch: MonkeyPatch, mock_data_1: pd.DataFrame, cache_type: s
 
     cache.dataframe_utils.save_df(mock_data_1, test_filename)
 
-    assert to_method.called_once_with(test_filename)
+    to_method.assert_called_once_with(test_filename)
 
 
 def test_save_invalid_cache_type(mock_data_1: pd.DataFrame) -> None:


### PR DESCRIPTION
## Summary
- support Python 3.12 in classifiers and docs
- adjust caching config to use property for directory
- fix tests for Python 3.12 compatibility

## Testing
- `pytest tests/pybaseball -q`

------
https://chatgpt.com/codex/tasks/task_e_68426cebded0833186ad820593a30d21